### PR TITLE
feat: 更新镜像站点文本和域名

### DIFF
--- a/app/components/Analystics.vue
+++ b/app/components/Analystics.vue
@@ -18,7 +18,7 @@ useHead({
     {
       rel: "icon",
       type: "image/x-icon",
-      href: "https://data.hyperos.fans/favicon.ico",
+      href: "https://hyposdt.pen-net.cn/favicon.ico",
     },
     {
       rel: "stylesheet",

--- a/app/components/Disclaimer.vue
+++ b/app/components/Disclaimer.vue
@@ -1,13 +1,13 @@
 <template>
   <div v-if="$device.isDesktopOrTablet">
     <v-footer class="text-center">
-      <v-col class="text-center">2023 - {{ new Date().getFullYear() }} | Hyper<span class="text-HyperBlue">OS</span>.fans | {{ $t('disclaimerlong') }}</v-col>
+      <v-col class="text-center">2023 - {{ new Date().getFullYear() }} | Hyper<span class="text-HyperBlue">OS</span>.fans <span class="text-HyperBlue">镜像</span> | {{ $t('disclaimerlong') }}</v-col>
     </v-footer>
     <!-- PC Disclaimer -->
   </div>
   <div v-else>
     <v-footer class="text-center">
-      <v-col class="text-center">2023 - {{ new Date().getFullYear() }} | Hyper<span class="text-HyperBlue">OS</span>.fans | {{ $t('disclaimer') }}</v-col>
+      <v-col class="text-center">2023 - {{ new Date().getFullYear() }} | Hyper<span class="text-HyperBlue">OS</span>.fans <span class="text-HyperBlue">镜像</span> | {{ $t('disclaimer') }}</v-col>
     </v-footer>
     <!-- Mobile Disclaimer -->
   </div>

--- a/app/components/Nav.vue
+++ b/app/components/Nav.vue
@@ -5,7 +5,7 @@
   <div v-if="$device.isDesktopOrTablet">
     <v-app-bar :elevation="2" rounded>
       <v-app-bar-title>
-        <b>Hyper<span class="text-HyperBlue">OS</span>.fans</b>
+        <b>Hyper<span class="text-HyperBlue">OS</span>.fans <span class="text-HyperBlue">镜像</span></b>
       </v-app-bar-title>
       <v-tabs v-model="tab" stacked class="text-HyperBlue NavLinks">
         <a v-for="(item, i) in items" :key="i" :value="item" :href="('/' + locale + '/' + item['path'])">
@@ -36,7 +36,7 @@
   <div v-else>
     <v-app-bar elevation="2" rounded>
       <v-btn icon="mdi-menu" @click.stop="drawer = !drawer"></v-btn>
-      <v-app-bar-title><b>Hyper<span class="text-HyperBlue">OS</span>.fans</b></v-app-bar-title>
+      <v-app-bar-title><b>Hyper<span class="text-HyperBlue">OS</span>.fans <span class="text-HyperBlue">镜像</span></b></v-app-bar-title>
     </v-app-bar>
     <v-navigation-drawer v-model="drawer">
       <v-list>
@@ -100,8 +100,8 @@ const availableLocales = computed(() => {
 let url = useRequestURL()
 const route = useRoute()
 let domain = url.hostname
-if (domain == "https://www.hyperos.fans") {
-  url = 'https://hyperos.fans' + route.path
+if (domain == "https://www.hyperos.pen-net.cn") {
+  url = 'https://hyperos.pen-net.cn' + route.path
   await navigateTo(url, { external: true })
 }
 

--- a/app/error.vue
+++ b/app/error.vue
@@ -4,8 +4,8 @@ const error = useError()
 let url = useRequestURL()
 const route = useRoute()
 let domain = url.hostname
-if (domain == "https://www.hyperos.fans") {
-  url = 'https://hyperos.fans' + route.path
+if (domain == "https://www.hyperos.pen-net.cn") {
+  url = 'https://hyperos.pen-net.cn' + route.path
   await navigateTo(url, { external: true })
 }
 </script>

--- a/app/pages/dev/[week].vue
+++ b/app/pages/dev/[week].vue
@@ -113,6 +113,6 @@ export default {
 <script setup>
 const route = useRoute()
 const { locale } = useI18n();
-const url = "https://data.hyperos.fans/dev/" + route.params.week.toLowerCase() + ".json"
+const url = "https://hyposdt.pen-net.cn/dev/" + route.params.week.toLowerCase() + ".json"
 const { data } = await useFetch(url)
 </script>

--- a/app/pages/dev/index.vue
+++ b/app/pages/dev/index.vue
@@ -28,6 +28,6 @@ export default {
 </script>
 <script setup>
 const { locale, locales } = useI18n()
-const url = "https://data.hyperos.fans/dev.json"
+const url = "https://hyposdt.pen-net.cn/dev.json"
 const { data } = await useFetch(url)
 </script>

--- a/app/pages/devices/[codename]/index.vue
+++ b/app/pages/devices/[codename]/index.vue
@@ -95,6 +95,6 @@ export default {
 const route = useRoute();
 const {locale} = useI18n();
 const url =
-	"https://data.hyperos.fans/devices/" + route.params.codename.toLowerCase() + ".json";
+        "https://hyposdt.pen-net.cn/devices/" + route.params.codename.toLowerCase() + ".json";
 const { data } = await useFetch(url);
 </script>

--- a/app/pages/devices/index.vue
+++ b/app/pages/devices/index.vue
@@ -13,7 +13,7 @@
 								<v-col v-for="devices in alldevices['devices']">
 									<v-card class="mx-auto" max-width="600" :href="('/'+locale+'/devices/'+devices['code'])">
 										<v-img
-											:src="'https://data.hyperos.fans/assets/images/' +devices['image']"
+                                                                                        :src="'https://hyposdt.pen-net.cn/assets/images/' +devices['image']"
 											class="align-end"
 											height="200px"
 											style="margin-top:10px;"
@@ -55,6 +55,6 @@ export default {
 </script>
 <script setup>
 const { locale, locales } = useI18n();
-const url = "https://data.hyperos.fans/devices.json";
+const url = "https://hyposdt.pen-net.cn/devices.json";
 const { data } = await useFetch(url);
 </script>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -97,13 +97,13 @@ export default {
 let url = useRequestURL()
 const route = useRoute()
 let domain = url.hostname
-if (domain == "https://www.hyperos.fans") {
-  url = 'https://hyperos.fans' + route.path
+if (domain == "https://www.hyperos.pen-net.cn") {
+  url = 'https://hyperos.pen-net.cn' + route.path
   await navigateTo(url, { external: true })
 }
 const { locale, locales } = useI18n()
-const index = "https://data.hyperos.fans/index.json"
-const site = "https://data.hyperos.fans/sitelog.json"
+const index = "https://hyposdt.pen-net.cn/index.json"
+const site = "https://hyposdt.pen-net.cn/sitelog.json"
 const { data: home } = await useFetch(index)
 const { data: sitelog } = await useFetch(site)
 </script>

--- a/app/pages/sitelog.vue
+++ b/app/pages/sitelog.vue
@@ -39,6 +39,6 @@ export default {
 </script>
 <script setup>
 const { locale, locales } = useI18n()
-const site = "https://data.hyperos.fans/sitelog.json"
+const site = "https://hyposdt.pen-net.cn/sitelog.json"
 const { data: sitelog } = await useFetch(site)
 </script>

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -3,7 +3,7 @@ module.exports = {
     {
       name: 'HyperOS.fans',
       port: '80',
-      host: 'hyperos.fans',
+      host: 'hyperos.pen-net.cn',
       exec_mode: 'cluster',
       instances: 'max',
       script: './.output/server/index.mjs'

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -50,7 +50,7 @@ export default ({
   },
 
   site: {
-    url: 'https://hyperos.fans',
+    url: 'https://hyperos.pen-net.cn',
   },
 
   compatibilityDate: '2024-07-31',

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
-Sitemap: https://hyperos.fans/sitemap.xml
+Sitemap: https://hyperos.pen-net.cn/sitemap.xml
 User-agent: *
 Disallow:

--- a/public/vMDUI/app.config.ts
+++ b/public/vMDUI/app.config.ts
@@ -19,7 +19,7 @@ export default defineAppConfig({
         {
           rel: "icon",
           type: "image/x-icon",
-          href: "https://www.hyperos.fans/favicon.ico",
+          href: "https://hyperos.pen-net.cn/favicon.ico",
         },
         {
           rel: "stylesheet",

--- a/public/vMDUI/assets/hyper.css
+++ b/public/vMDUI/assets/hyper.css
@@ -5,7 +5,7 @@ body {
 	font-family: Material Icons;
 	font-style: normal;
 	font-weight: 400;
-	src: url(https://data.hyperos.fans/assets/fonts/Material_Icons.woff2)
+        src: url(https://hyposdt.pen-net.cn/assets/fonts/Material_Icons.woff2)
 		format("woff2");
 }
 a {

--- a/public/vMDUI/nuxt.config.ts
+++ b/public/vMDUI/nuxt.config.ts
@@ -34,6 +34,6 @@ export default defineNuxtConfig({
     },
   },
   site: {
-    url: 'https://www.hyperos.fans',
+    url: 'https://hyperos.pen-net.cn',
   }
 })

--- a/public/vMDUI/pages/dev/[week].vue
+++ b/public/vMDUI/pages/dev/[week].vue
@@ -71,7 +71,7 @@
 <script setup>
 const route = useRoute()
 const {locale} = useI18n();
-const url = "https://data.hyperos.fans/dev/" + route.params.week + ".json"
+const url = "https://hyposdt.pen-net.cn/dev/" + route.params.week + ".json"
 const { data } = await useFetch(url)
 </script>
 

--- a/public/vMDUI/pages/dev/index.vue
+++ b/public/vMDUI/pages/dev/index.vue
@@ -18,6 +18,6 @@
 </template>
 <script setup>
 const {locale} = useI18n();
-const url = "https://data.hyperos.fans/dev.json"
+const url = "https://hyposdt.pen-net.cn/dev.json"
 const { data } = await useFetch(url)
 </script>

--- a/public/vMDUI/pages/devices/[codename]/[version]/index.vue
+++ b/public/vMDUI/pages/devices/[codename]/[version]/index.vue
@@ -8,7 +8,7 @@
 <script setup>
 const route = useRoute()
 const {locale} = useI18n();
-const url = "https://data.hyperos.fans/devices/" + route.params.codename + ".json"
+const url = "https://hyposdt.pen-net.cn/devices/" + route.params.codename + ".json"
 const { data } = await useFetch(url)
 
 </script>

--- a/public/vMDUI/pages/devices/[codename]/index.vue
+++ b/public/vMDUI/pages/devices/[codename]/index.vue
@@ -46,6 +46,6 @@
 <script setup>
 const route = useRoute()
 const {locale} = useI18n();
-const url = "https://data.hyperos.fans/devices/" + route.params.codename + ".json"
+const url = "https://hyposdt.pen-net.cn/devices/" + route.params.codename + ".json"
 const { data } = await useFetch(url)
 </script>

--- a/public/vMDUI/pages/devices/index.vue
+++ b/public/vMDUI/pages/devices/index.vue
@@ -13,6 +13,6 @@
 </template>
 <script setup>
 const {locale} = useI18n();
-const url = "https://data.hyperos.fans/devices.json"
+const url = "https://hyposdt.pen-net.cn/devices.json"
 const { data } = await useFetch(url)
 </script>

--- a/public/vMDUI/pages/index.vue
+++ b/public/vMDUI/pages/index.vue
@@ -33,9 +33,9 @@
 
 <script setup>
 const {locale} = useI18n();
-const devices = "https://data.hyperos.fans/devices.json"
-const index = "https://data.hyperos.fans/index.json"
+const devices = "https://hyposdt.pen-net.cn/devices.json"
+const index = "https://hyposdt.pen-net.cn/index.json"
 const { data:device } = await useFetch(devices)
 const { data:home } = await useFetch(index)
-const { data:latest } = await useFetch('https://data.hyperos.fans/dev/'+home.value.latest+'.json')
+const { data:latest } = await useFetch('https://hyposdt.pen-net.cn/dev/'+home.value.latest+'.json')
 </script>


### PR DESCRIPTION
## Summary
- 在导航栏和页脚增加“镜像”标识并同步颜色
- 将数据源域名替换为 hyposdt.pen-net.cn
- 更新站点域名配置及 robots.txt 指向 hyperos.pen-net.cn

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b06dbce6d4832581ca6baa4e93886d