### PR TITLE
Label site titles as HyperOS.fans mirror

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,5 +1,5 @@
 export default({
-  title: 'HyperOS.fans',
+  title: 'HyperOS.fans 镜像',
   ssr: true,
   target: "static",
   components: true,

--- a/app/pages/dev/[week].vue
+++ b/app/pages/dev/[week].vue
@@ -1,6 +1,6 @@
 <template>
-  <title v-if="locale == 'en'">HyperOS {{ data['title'][locale] }} - HyperOS.fans</title>
-  <title v-else>HyperOS {{ data['title'][locale] }} - HyperOS.fans</title>
+  <title v-if="locale == 'en'">HyperOS {{ data['title'][locale] }} - HyperOS.fans 镜像</title>
+  <title v-else>HyperOS {{ data['title'][locale] }} - HyperOS.fans 镜像</title>
   <v-app>
     <Nav></Nav>
     <Space></Space>

--- a/app/pages/dev/index.vue
+++ b/app/pages/dev/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <title>{{ $t('devtitle') }} - HyperOS.fans</title>
+  <title>{{ $t('devtitle') }} - HyperOS.fans 镜像</title>
   <v-app>
     <Nav></Nav>
     <v-card v-for="os in data['HyperOS']" elevation="2">

--- a/app/pages/devices/[codename]/index.vue
+++ b/app/pages/devices/[codename]/index.vue
@@ -1,10 +1,10 @@
 <template>
-	<title v-if="locale == 'en'">
-		{{ $t("rompage") }} {{ data['name'][locale] }} - HyperOS.fans
-	</title>
-	<title v-else>
-		{{ data['name'][locale] }} {{ $t("rompage") }} - HyperOS.fans
-	</title>
+        <title v-if="locale == 'en'">
+                {{ $t("rompage") }} {{ data['name'][locale] }} - HyperOS.fans 镜像
+        </title>
+        <title v-else>
+                {{ data['name'][locale] }} {{ $t("rompage") }} - HyperOS.fans 镜像
+        </title>
 	<v-app>
 		<Nav></Nav>
 		<Space></Space>

--- a/app/pages/devices/index.vue
+++ b/app/pages/devices/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <title>{{ $t('devlist') }} - HyperOS.fans</title>
+  <title>{{ $t('devlist') }} - HyperOS.fans 镜像</title>
 		<v-app>
 			<Nav></Nav>
 			<v-expansion-panels variant="accordion" v-model="panel">

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
     <span v-if="home['recent']['developing'] == 'no'">
-      <title>{{ $t('hometitle') }} - HyperOS.fans</title>
+      <title>{{ $t('hometitle') }} - HyperOS.fans 镜像</title>
       <Nav></Nav>
       <v-card elevation="2">
         <v-card-item>
@@ -77,7 +77,7 @@
       <Footer></Footer>
     </span>
     <span v-else>
-      <title>{{ $t('dev_title') }} - HyperOS.fans</title>
+      <title>{{ $t('dev_title') }} - HyperOS.fans 镜像</title>
       <div class="developing">{{ $t('developing') }}</div>
     </span>
   </v-app>

--- a/app/pages/sitelog.vue
+++ b/app/pages/sitelog.vue
@@ -1,5 +1,5 @@
 <template>
-    <title>{{ $t('sitelog') }} - HyperOS.fans</title>
+    <title>{{ $t('sitelog') }} - HyperOS.fans 镜像</title>
   <v-app>
     <Nav></Nav>
     <v-timeline align="start" size="large" side="end">

--- a/app/pages/source.vue
+++ b/app/pages/source.vue
@@ -1,5 +1,5 @@
 <template>
-  <title>{{ $t('source') }} - HyperOS.fans</title>
+  <title>{{ $t('source') }} - HyperOS.fans 镜像</title>
 <v-app>
   <Nav></Nav>
   <v-card elevation="2">

--- a/app/pages/tips/403.vue
+++ b/app/pages/tips/403.vue
@@ -1,6 +1,6 @@
 <template>
-  <title v-if="locale == 'en'">{{ $t('fix403') }} - HyperOS.fans</title>
-  <title v-else> {{ $t('fix403') }} - HyperOS.fans</title>
+  <title v-if="locale == 'en'">{{ $t('fix403') }} - HyperOS.fans 镜像</title>
+  <title v-else> {{ $t('fix403') }} - HyperOS.fans 镜像</title>
   <v-app>
     <Nav></Nav>
     <Space></Space>

--- a/public/vMDUI/app.config.ts
+++ b/public/vMDUI/app.config.ts
@@ -1,5 +1,5 @@
 export default defineAppConfig({
-  title: 'HyperOS.fans',
+  title: 'HyperOS.fans 镜像',
   css: ['mdui.css', '~/assets/main.css'],
   ssr: true,
   target: "static",

--- a/public/vMDUI/components/MDUI.vue
+++ b/public/vMDUI/components/MDUI.vue
@@ -1,7 +1,7 @@
 <template></template>
 <script setup lang="ts">
 useHead({
-  title: 'HyperOS.fans',
+  title: 'HyperOS.fans 镜像',
   link: [
     {
       rel: "icon",

--- a/public/vMDUI/pages/dev/[week].vue
+++ b/public/vMDUI/pages/dev/[week].vue
@@ -1,6 +1,6 @@
 <template>
-  <title v-if="locale == 'en'"> {{ data.title[locale] }} - HyperOS.fans</title>
-  <title v-else>{{ data.title[locale] }} - HyperOS.fans</title>
+  <title v-if="locale == 'en'"> {{ data.title[locale] }} - HyperOS.fans 镜像</title>
+  <title v-else>{{ data.title[locale] }} - HyperOS.fans 镜像</title>
   <mdui-card style="width: 99vw;padding-bottom: 20px;align-items: center;margin-top:1vw;margin-right:1vw">
     <div style="padding-left:10px;padding-top:10px">
       <h3 class="text-HyperBlue">{{ data.title[locale] }}</h3>

--- a/public/vMDUI/pages/dev/index.vue
+++ b/public/vMDUI/pages/dev/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <title>{{ $t('devtitle') }} - HyperOS.fans</title>
+  <title>{{ $t('devtitle') }} - HyperOS.fans 镜像</title>
   <mdui-card style="width: 99vw;padding-bottom: 20px;align-items: center;margin-top:1vw;margin-right:1vw">
     <h3 style="padding-left:10px;">
       <span v-for="{ bigVer, latest, weeks } in data.HyperOS" style="padding-left:10px">{{ bigVer }}

--- a/public/vMDUI/pages/devices/[codename]/index.vue
+++ b/public/vMDUI/pages/devices/[codename]/index.vue
@@ -1,6 +1,6 @@
 <template>
-  <title v-if="locale == 'en'">{{ $t('rompage') }} {{ data.name[locale] }} - HyperOS.fans</title>
-  <title v-else>{{ data.name[locale] }} {{ $t('rompage') }} - HyperOS.fans</title>
+  <title v-if="locale == 'en'">{{ $t('rompage') }} {{ data.name[locale] }} - HyperOS.fans 镜像</title>
+  <title v-else>{{ data.name[locale] }} {{ $t('rompage') }} - HyperOS.fans 镜像</title>
   <mdui-card style="width: 99vw;height: 170px;align-items: center;margin-top:1vw;margin-right:1vw">
     <p style="padding-left:10px;">{{ $t('name') }} ： <span>{{ data.name[locale] }}</span></p>
     <p style="padding-left:10px;">{{ $t('codename') }} ： <span>{{ data.device }}</span></p>

--- a/public/vMDUI/pages/devices/index.vue
+++ b/public/vMDUI/pages/devices/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <title>{{ $t('devlist') }} - HyperOS.fans</title>
+  <title>{{ $t('devlist') }} - HyperOS.fans 镜像</title>
   <mdui-card style="width: 99vw;padding-bottom: 20px;align-items: center;margin-top:1vw;margin-right:1vw">
     <div style="padding-left:10px;padding-top:10px">
       <NuxtLink v-for="{ code, name } in data.mi" :to="('/' + locale + '/devices/' + code)" class="text-HyperBlue" style="margin-right: 5px;">

--- a/public/vMDUI/pages/index.vue
+++ b/public/vMDUI/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <title>{{ $t('hometitle') }} - HyperOS.fans</title>
+  <title>{{ $t('hometitle') }} - HyperOS.fans 镜像</title>
   <mdui-card style="width: 99vw;padding-bottom: 20px;align-items: center;margin-top:1vw;margin-right:1vw">
     <h3 style="padding-left:10px;">{{ $t('sitev') }}<span class="text-HyperBlue">{{ home.siteVer }}</span></h3>
     <h3 style="padding-left:10px;">{{ $t('supported') }}</h3><span v-for="({ code, name },index) in device.mi" style="padding-left:10px;text-indent: 20px;">

--- a/public/vMDUI/pages/tips/403.vue
+++ b/public/vMDUI/pages/tips/403.vue
@@ -1,6 +1,6 @@
 <template>
-  <title v-if="locale == 'en'">{{ $t('fix403') }} - HyperOS.fans</title>
-  <title v-else> {{ $t('fix403') }} - HyperOS.fans</title>
+  <title v-if="locale == 'en'">{{ $t('fix403') }} - HyperOS.fans 镜像</title>
+  <title v-else> {{ $t('fix403') }} - HyperOS.fans 镜像</title>
   <mdui-card style="width: 99vw;align-items: center;margin-top:1vw;margin-right:1vw">
     <div style="padding-left:10px;">
       <h3>{{ $t('method1') }}</h3>


### PR DESCRIPTION
## Summary
- update default site title to "HyperOS.fans 镜像"
- replace `HyperOS.fans` with `HyperOS.fans 镜像` across page `<title>` tags

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b0726f89d48325b1587bf85e7a8a5f